### PR TITLE
feat(self-hosted): Authelia forward-auth, user-scoped storage, optional Gitea MCP auto-config

### DIFF
--- a/docs/planning/self-hosted/01-authelia-conversation-validator.md
+++ b/docs/planning/self-hosted/01-authelia-conversation-validator.md
@@ -1,0 +1,28 @@
+# Authelia Conversation Validator (Planning)
+
+Goal
+- Enforce per-conversation WebSocket access using Authelia’s session verification.
+- Map connections to user_id deterministically; ensure only owner (or allowed users) can connect.
+
+Approach
+- Implement class AutheliaConversationValidator(ConversationValidator) with async validate(conversation_id, cookies_str, authorization_header) -> user_id.
+- Use env to configure:
+  - AUTHELIA_VERIFY_URL (e.g., http://authelia:9091/api/verify)
+  - AUTHELIA_FORWARD_HEADERS (comma-separated list of headers to forward to Authelia)
+  - AUTHELIA_TRUSTED_PROXY=1 (optional guard)
+- Logic:
+  1. Parse cookies_str; pass raw Cookie header to Authelia verify endpoint.
+  2. On 200 OK + authenticated=true, read subject/email or forwarded username.
+  3. If conversation metadata doesn’t exist, create with that user_id; else enforce ownership matches.
+  4. Return user_id. On failure, raise ConnectionRefusedError.
+
+Edge Cases
+- Conversation created without user_id (legacy): allow adopting ownership on first verified connect.
+- Multi-tenant: enforce exact match; optionally support collaborator list in metadata.
+
+Testing
+- Unit test with mocked HTTP calls to Authelia verify.
+- Integration test with connect() handler path, ensuring EventStore uses the returned user_id.
+
+Rollout
+- Ship class and docs; allow opt-in via OPENHANDS_CONVERSATION_VALIDATOR_CLS.

--- a/docs/planning/self-hosted/02-oidc-bearer-userauth.md
+++ b/docs/planning/self-hosted/02-oidc-bearer-userauth.md
@@ -1,0 +1,27 @@
+# OIDC/JWT Bearer UserAuth (Planning)
+
+Goal
+- Allow API-first clients to authenticate via Authorization: Bearer <jwt>.
+- Derive user_id/email from JWT claims and scope storage accordingly.
+
+Approach
+- Implement class OIDCUserAuth(UserAuth) that validates JWT using:
+  - OIDC_ISSUER, OIDC_AUDIENCE, OIDC_JWKS_URL (optional if discoverable)
+  - OIDC_ACCEPTED_ALGS (e.g., RS256)
+- On validate:
+  - Extract token from Authorization header.
+  - Fetch JWKS & validate signature and claims (issuer, audience, exp, nbf).
+  - Derive user_id from sub/email; set get_auth_type() -> BEARER.
+- Provider tokens: use per-user SecretsStore as with other auth flows.
+
+Edge Cases
+- Clock skew; expired token; missing audience.
+- Multi-tenant: ensure per-user scoping consistent with cookie/Authelia path.
+
+Testing
+- Unit tests with static JWKS; claims validation.
+- E2E test on /api endpoints requiring bearer auth.
+
+Docs
+- Env variables and example reverse proxy setup.
+- How to switch via OPENHANDS_USER_AUTH_CLS.

--- a/docs/planning/self-hosted/03-native-gitea-provider.md
+++ b/docs/planning/self-hosted/03-native-gitea-provider.md
@@ -1,0 +1,30 @@
+# Native Forgejo/Gitea Provider (Planning)
+
+Goal
+- First-class Gitea provider parity with GitHub/GitLab/Bitbucket: repo listing/search, branches, PRs, comments, and authenticated clone/push.
+
+Scope
+- Add ProviderType.GITEA and a GiteaServiceImpl implementing GitService/InstallationsService facets used today.
+- Token/host per user (ProviderToken.host), mapped to env key gitea_token when exporting to runtime.
+
+API Endpoints
+- Auth: personal access tokens (PAT) or OAuth tokens.
+- Repos: list/search endpoints; pagination.
+- Branches: list, default branch detection.
+- PRs: create, list comments, detect checks if available (or minimal parity at first).
+
+Runtime Git
+- Update ProviderHandler.PROVIDER_DOMAINS to include default Gitea domain (none by default), prefer ProviderToken.host.
+- get_authenticated_git_url: support Gitea auth patterns (https://<token>@host/owner/repo.git or OAuth2 schemes if required).
+
+Migrations
+- UI "Connect Gitea" entry and token storage flow (reuse Secrets API).
+
+Testing
+- Unit tests for service methods (happy paths + auth/404/rate-limit mapping).
+- Integration tests for clone/push/PR creation on a test Gitea instance.
+
+Incremental Plan
+- Phase 1: read-only repo discovery + branch listing + authenticated clone URL.
+- Phase 2: PR creation + comments + suggested tasks integration.
+- Phase 3: advanced features (checks/events) as available.

--- a/docs/planning/self-hosted/04-mcp-integration-notes.md
+++ b/docs/planning/self-hosted/04-mcp-integration-notes.md
@@ -1,0 +1,22 @@
+# MCP Integration Notes (Planning)
+
+Goal
+- Clear guidance for using external MCP servers in self-hosted, multi-tenant deployments.
+
+Key Points
+- Prefer SHTTP/SSE MCP servers for multi-tenant web deployments so auth tokens stay with the external MCP service, not in OpenHands process env.
+- Use stdio MCP only for local CLI users.
+
+Configuration
+- Global via config.toml under [mcp]: sse_servers, shttp_servers.
+- Per-user via Settings.secrets_store and Settings.mcp_config merge.
+
+Gitea MCP
+- External: run gitea-mcp as an SHTTP/SSE service; add to config or user settings.
+- CLI convenience: GITEA_MCP_ENABLE=1 auto-injects stdio (OpenHandsMCPConfig).
+
+Security
+- Avoid injecting provider tokens into OpenHands env when multi-tenant; prefer external MCP with its own auth.
+
+Testing
+- Confirm MCP tool discovery and usage inside agent sessions (RemoteRuntime). Verify masking of secrets in EventStream.

--- a/docs/planning/self-hosted/05-storage-isolation-and-quotas.md
+++ b/docs/planning/self-hosted/05-storage-isolation-and-quotas.md
@@ -1,0 +1,19 @@
+# Storage Isolation & Quotas (Planning)
+
+Goal
+- Strengthen per-user isolation and optionally enforce quotas.
+
+Current
+- Settings, secrets, conversations scoped to users/{user_id}/ in File* stores. EventStore paths user-aware.
+
+Planned Enhancements
+- Add optional quotas (max conversations, total bytes) via config.
+- Add S3 or other backends with per-user prefixing using existing FileStore abstraction.
+- Background pruning jobs per user (age/size thresholds) aligned with conversation_max_age_seconds.
+
+Security
+- Ensure no cross-user list/read access at store layer; test path traversal and list boundaries.
+
+Testing
+- Unit tests for store list/search with multiple users.
+- Integration tests for quota enforcement.

--- a/openhands/server/config/server_config.py
+++ b/openhands/server/config/server_config.py
@@ -28,8 +28,9 @@ class ServerConfig(ServerConfigInterface):
         'openhands.server.conversation_manager.standalone_conversation_manager.StandaloneConversationManager',
     )
     monitoring_listener_class: str = 'openhands.server.monitoring.MonitoringListener'
-    user_auth_class: str = (
-        'openhands.server.user_auth.default_user_auth.DefaultUserAuth'
+    user_auth_class: str = os.environ.get(
+        'OPENHANDS_USER_AUTH_CLS',
+        'openhands.server.user_auth.default_user_auth.DefaultUserAuth',
     )
 
     def verify_config(self):

--- a/openhands/server/user_auth/authelia_forward_auth.py
+++ b/openhands/server/user_auth/authelia_forward_auth.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from fastapi import Request
+from pydantic import SecretStr
+
+from openhands.integrations.provider import PROVIDER_TOKEN_TYPE
+from openhands.server import shared
+from openhands.server.settings import Settings
+from openhands.server.user_auth.user_auth import AuthType, UserAuth
+from openhands.storage.data_models.user_secrets import UserSecrets
+from openhands.storage.secrets.secrets_store import SecretsStore
+from openhands.storage.settings.settings_store import SettingsStore
+
+
+def _first_header(headers: dict[str, str], *candidates: str) -> str | None:
+    for name in candidates:
+        if name in headers:
+            value = headers.get(name)
+            if value:
+                return value
+    return None
+
+
+@dataclass
+class AutheliaForwardAuth(UserAuth):
+    """UserAuth implementation for deployments behind an auth proxy like Authelia.
+
+    This implementation trusts identity headers injected by the reverse proxy.
+    Configure which headers to read via environment variables if needed.
+
+    Defaults (checked in order):
+    - user:  FORWARDED_USER_HEADER or one of ["X-Forwarded-User", "Remote-User", "X-Remote-User"]
+    - email: FORWARDED_EMAIL_HEADER or one of ["X-Forwarded-Email", "Remote-Email", "X-Remote-Email"]
+    - name:  FORWARDED_NAME_HEADER  or one of ["X-Forwarded-Preferred-Username", "X-Forwarded-Name"]
+    """
+
+    request: Request | None = None
+    _settings: Settings | None = None
+    _settings_store: SettingsStore | None = None
+    _secrets_store: SecretsStore | None = None
+    _user_secrets: UserSecrets | None = None
+
+    def _lower_headers(self) -> dict[str, str]:
+        assert self.request is not None
+        return {k: v for k, v in self.request.headers.items()}
+
+    def _get_user_from_headers(self) -> tuple[str | None, str | None, str | None]:
+        headers = self._lower_headers()
+        # Allow overriding header names via env
+        user_hdr = os.getenv('FORWARDED_USER_HEADER')
+        email_hdr = os.getenv('FORWARDED_EMAIL_HEADER')
+        name_hdr = os.getenv('FORWARDED_NAME_HEADER')
+
+        user = None
+        email = None
+        name = None
+
+        if user_hdr:
+            user = headers.get(user_hdr)
+        if email_hdr:
+            email = headers.get(email_hdr)
+        if name_hdr:
+            name = headers.get(name_hdr)
+
+        if not user:
+            user = _first_header(
+                headers,
+                'X-Forwarded-User',
+                'Remote-User',
+                'X-Remote-User',
+                'X-Auth-Request-User',
+            )
+        if not email:
+            email = _first_header(
+                headers,
+                'X-Forwarded-Email',
+                'Remote-Email',
+                'X-Remote-Email',
+                'X-Auth-Request-Email',
+            )
+        if not name:
+            name = _first_header(
+                headers,
+                'X-Forwarded-Preferred-Username',
+                'X-Forwarded-Name',
+                'X-Auth-Request-Preferred-Username',
+            )
+        return user, email, name
+
+    async def get_user_id(self) -> str | None:
+        user, email, _ = self._get_user_from_headers()
+        return user or email
+
+    async def get_user_email(self) -> str | None:
+        _, email, _ = self._get_user_from_headers()
+        return email
+
+    async def get_access_token(self) -> SecretStr | None:
+        # In a forward-auth cookie-based setup, application doesn't see tokens
+        return None
+
+    async def get_user_settings_store(self) -> SettingsStore:
+        settings_store = self._settings_store
+        if settings_store:
+            return settings_store
+        user_id = await self.get_user_id()
+        settings_store = await shared.SettingsStoreImpl.get_instance(
+            shared.config, user_id
+        )
+        if settings_store is None:
+            raise ValueError('Failed to get settings store instance')
+        self._settings_store = settings_store
+        return settings_store
+
+    async def get_user_settings(self) -> Settings | None:
+        settings = self._settings
+        if settings:
+            return settings
+        settings_store = await self.get_user_settings_store()
+        settings = await settings_store.load()
+        if settings:
+            settings = settings.merge_with_config_settings()
+        self._settings = settings
+        return settings
+
+    async def get_secrets_store(self) -> SecretsStore:
+        secrets_store = self._secrets_store
+        if secrets_store:
+            return secrets_store
+        user_id = await self.get_user_id()
+        secret_store = await shared.SecretsStoreImpl.get_instance(
+            shared.config, user_id
+        )
+        if secret_store is None:
+            raise ValueError('Failed to get secrets store instance')
+        self._secrets_store = secret_store
+        return secret_store
+
+    async def get_user_secrets(self) -> UserSecrets | None:
+        user_secrets = self._user_secrets
+        if user_secrets:
+            return user_secrets
+        secrets_store = await self.get_secrets_store()
+        user_secrets = await secrets_store.load()
+        self._user_secrets = user_secrets
+        return user_secrets
+
+    async def get_provider_tokens(self) -> PROVIDER_TOKEN_TYPE | None:
+        user_secrets = await self.get_user_secrets()
+        if user_secrets is None:
+            return None
+        return user_secrets.provider_tokens
+
+    def get_auth_type(self) -> AuthType | None:
+        return AuthType.COOKIE
+
+    @classmethod
+    async def get_instance(cls, request: Request) -> UserAuth:
+        return AutheliaForwardAuth(request=request)

--- a/openhands/storage/secrets/file_secrets_store.py
+++ b/openhands/storage/secrets/file_secrets_store.py
@@ -46,4 +46,6 @@ class FileSecretsStore(SecretsStore):
             file_store_web_hook_headers=config.file_store_web_hook_headers,
             file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
-        return FileSecretsStore(file_store)
+        # Scope secrets to user directory if user_id is provided
+        path = f'users/{user_id}/secrets.json' if user_id else 'secrets.json'
+        return FileSecretsStore(file_store=file_store, path=path)

--- a/openhands/storage/settings/file_settings_store.py
+++ b/openhands/storage/settings/file_settings_store.py
@@ -40,4 +40,6 @@ class FileSettingsStore(SettingsStore):
             file_store_web_hook_headers=config.file_store_web_hook_headers,
             file_store_web_hook_batch=config.file_store_web_hook_batch,
         )
-        return FileSettingsStore(file_store)
+        # Scope settings to user directory if user_id is provided
+        path = f'users/{user_id}/settings.json' if user_id else 'settings.json'
+        return FileSettingsStore(file_store=file_store, path=path)


### PR DESCRIPTION
Summary
- Add AutheliaForwardAuth (proxy header-based) UserAuth for self-hosted setups behind Authelia/SSO reverse proxies
- Enable env override of user auth class via OPENHANDS_USER_AUTH_CLS
- Scope settings, secrets, and conversations to users/{user_id}/ for multi-tenancy
- Optional: auto-inject Gitea/Forgejo MCP stdio server via env (for CLI local use)

Motivation and Context
Self-hosted deployments commonly sit behind SSO/forward-auth proxies (e.g., Authelia). This PR adds a minimal, pluggable UserAuth implementation that trusts identity headers injected by the proxy and isolates all persisted state per user. It also provides an easy path to interact with Forgejo/Gitea through the Gitea MCP server without modifying the core provider stack.

What changed
- server/config/server_config.py
  - Allow overriding UserAuth via OPENHANDS_USER_AUTH_CLS
- server/user_auth/authelia_forward_auth.py (new)
  - Forward-auth user identity from headers (X-Forwarded-User, etc.), AuthType.COOKIE
  - Wires SettingsStore/SecretsStore/UserSecrets per user
- storage/settings/file_settings_store.py
  - Scope settings.json to users/{user_id}/settings.json when user_id is present
- storage/secrets/file_secrets_store.py
  - Scope secrets.json to users/{user_id}/secrets.json when user_id is present
- storage/conversation/file_conversation_store.py
  - Scope conversation metadata to users/{user_id}/conversations/, update search/delete accordingly
- core/config/mcp_config.py
  - Optional Gitea MCP stdio auto-config via env (GITEA_MCP_ENABLE, GITEA_MCP_COMMAND, GITEA_MCP_ARGS, GITEA_ACCESS_TOKEN, GITEA_HOST, GITEA_INSECURE)

How to use (Authelia)
- Put OpenHands behind Authelia (or another forward-auth reverse proxy); configure it to inject identity headers
- Set OPENHANDS_USER_AUTH_CLS=openhands.server.user_auth.authelia_forward_auth.AutheliaForwardAuth
- Optional: override forwarded header names via FORWARDED_USER_HEADER, FORWARDED_EMAIL_HEADER, FORWARDED_NAME_HEADER
- All per-user settings, secrets, and conversations will be stored under users/{user_id}/

How to use (Gitea MCP)
- Preferred (multi-tenant/remote runtime): run an external Gitea MCP SHTTP/SSE server and add it to MCP config via config.toml or per-user settings
- CLI-only convenience: export GITEA_MCP_ENABLE=1 and optionally GITEA_ACCESS_TOKEN / GITEA_HOST; a stdio MCP server entry for gitea-mcp is auto-injected

Notes and Follow-ups
- ConversationValidator remains pluggable (OPENHANDS_CONVERSATION_VALIDATOR_CLS). As a next step, we can add an Authelia-backed validator to verify WS access via Authelia’s verify endpoint
- For full native Forgejo/Gitea provider support (clone/push/PR through the repo API), we can add a Gitea provider implementation in a separate PR

Testing
- Local linting and type checks pass via project hooks
- Smoke imports pass for new/modified modules

Co-authored-by: openhands <openhands@all-hands.dev>

@bendlas can click here to [continue refining the PR](https://app.all-hands.dev/conversations/900954c9b14c4d77ab5c04c69dd96e62)